### PR TITLE
Add `lugar` attr to event and display it

### DIFF
--- a/src/components/datatable.jsx
+++ b/src/components/datatable.jsx
@@ -93,7 +93,8 @@ class DataTable extends Component {
           participantes: eData[k].participantes,
           tipoEventos: eData[k].tipoEventos,
           ambito: eData[k].ambito,
-          discapacidad: eData[k].discapidad,
+          discapacidad: eData[k].discapacidad,
+          lugar: eData[k].lugar,
           fecha: this.getFecha(eData[k].fecha),
           horario: eData[k].horario
         });
@@ -134,6 +135,10 @@ class DataTable extends Component {
             {
               Header: "Participantes",
               accessor: "participantes"
+            },
+            {
+              Header: "Lugar",
+              accessor: "lugar"
             },
             {
               Header: "Fecha",

--- a/src/components/form.jsx
+++ b/src/components/form.jsx
@@ -12,6 +12,7 @@ class Form extends Component {
     participantes: "",
     fecha: "",
     horario: "",
+    lugar: "",
     ambito: "Escolar",
     discapidad: "Auditiva",
     tipoEventos: "Conferencia"
@@ -59,6 +60,7 @@ class Form extends Component {
         horario: this.props.data[index].horario,
         ambito: this.props.data[index].ambito,
         discapidad: this.props.data[index].discapacidad,
+        lugar: this.props.data[index].lugar,
         tipoEventos: this.props.data[index].tipoEventos
       }));
     }
@@ -66,6 +68,11 @@ class Form extends Component {
   handleNameChange = e => {
     const evento = e.target.value;
     this.setState(() => ({ evento }));
+  };
+
+  handleLugarChange = e => {
+    const lugar = e.target.value;
+    this.setState(({lugar}));
   };
 
   handleParticipants = e => {
@@ -133,6 +140,7 @@ class Form extends Component {
             ambito: this.state.ambito, //eData[k].ambito,
             discapidad: this.state.discapidad, //eData[k].discapidad,
             fecha: this.state.fecha, //this.getFecha(eData[k].fecha),
+            lugar: this.state.lugar,
             horario: this.state.horario //eData[k].horario
           });
       } else {
@@ -189,6 +197,13 @@ class Form extends Component {
                 value={this.state.participantes}
                 onChange={this.handleParticipants}
                 floatingLabelText="Participantes"
+                style={{ width: "80%" }}
+              />
+              <br />
+              <TextField
+                value={this.state.lugar}
+                onChange={this.handleLugarChange}
+                floatingLabelText="Lugar"
                 style={{ width: "80%" }}
               />
               <br />


### PR DESCRIPTION
## What does this PR do?

- Add `lugar` attribute to an event and use it when creating or editing an existing event.
- Fix typo on discapacidad to correctly display data on the table.